### PR TITLE
[TEST] Insecure mode with self-managed nodegroups only

### DIFF
--- a/examples/complete/fixtures.common.tfvars
+++ b/examples/complete/fixtures.common.tfvars
@@ -1,8 +1,8 @@
 ###########################################################
 ################## Global Settings ########################
 
-region  = "us-east-1" # target AWS region
-region2 = "us-east-2" # RDS backup target AWS region
+region  = "us-east-2" # target AWS region
+region2 = "us-east-1" # RDS backup target AWS region
 # default_tags = {
 #   Environment = "dev"
 #   Project     = "ci-eks"

--- a/examples/complete/fixtures.insecure.tfvars
+++ b/examples/complete/fixtures.insecure.tfvars
@@ -1,4 +1,4 @@
-enable_eks_managed_nodegroups  = true
+enable_eks_managed_nodegroups  = false
 enable_self_managed_nodegroups = true
 bastion_tenancy                = "default"
 eks_worker_tenancy             = "default"


### PR DESCRIPTION
I'm getting this error with secure mode of the complete example. I suspect it might have something to do with the difference between managed and self-managed nodegroups, in that whenever managed node groups are used the aws-auth configmap is created for us.

Testing by changing insecure mode to deploy managed nodegroups only (which should theoretically work) and running a test on it

<img width="1389" alt="image" src="https://user-images.githubusercontent.com/16000938/228008128-c06c7ddd-4649-45de-a1a6-ace05ac250ed.png">
